### PR TITLE
Added number support for token names

### DIFF
--- a/parsers/token.js
+++ b/parsers/token.js
@@ -26,7 +26,7 @@ export default class TokenParser {
     if (str.length < 2) return false;
 
     // a string matching a token definition eg. D3rp-asdsa
-    const reg = /^([A-Za-z][0-9][0-9]?)([grbypcdTSMLHG]?[grbypcdTSMLHG]?)(-([A-Za-z]*))?$/;
+    const reg = /^([A-Za-z][0-9][0-9]?)([grbypcdTSMLHG]?[grbypcdTSMLHG]?)(-([A-Za-z0-9]*))?$/;
     if (reg.test(trimmed)) {
       const matches = trimmed.match(reg);
 

--- a/test/input-parser.js
+++ b/test/input-parser.js
@@ -116,5 +116,44 @@ tap.test("token parsing", (t) => {
       }
     },
   ], 'tokens with size should match');
+
+  t.same(clone(new InputParser("/A1-ZOM1").tokens), [
+    {
+      x: 1,
+      y: 1,
+      item: {
+        name: "ZOM1",
+        color: "black",
+        size: 0.5,
+        offset: 0.5,
+      }
+    },
+  ], 'tokens with size should match');
+
+  t.same(clone(new InputParser("/A1-9ZOM1").tokens), [
+    {
+      x: 1,
+      y: 1,
+      item: {
+        name: "9ZOM1",
+        color: "black",
+        size: 0.5,
+        offset: 0.5,
+      }
+    },
+  ], 'tokens with size should match');
+
+  t.same(clone(new InputParser("/A1-123456").tokens), [
+    {
+      x: 1,
+      y: 1,
+      item: {
+        name: "123456",
+        color: "black",
+        size: 0.5,
+        offset: 0.5,
+      }
+    },
+  ], 'tokens with size should match');
   t.end();
 });


### PR DESCRIPTION
Bug fix for https://github.com/digitalsadhu/otf-battlemaps/issues/13

### Changes
* Updated regex for token names to account for digits.
* Added unit tests

## Test procedure - Manual
Add tokens with and without digits in their names, ensure the tokens are populated

## Test procedure - Automated
Ensure unit tests pass 