### PR TITLE
Fit provided images and default textures within gutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,32 @@ _**Example**_
 ```
 http://otfbm.com/D3-Goblin/A1-Goblin/G4-Fighter
 ```
+
+## Background Images
+
+You can add images to your battle map by providing a link to an external image, or by using one of the default images provided by On The Fly Battle Maps.
+
+**Default Backgrounds**
+The default background images can be accessed by providing a `=#` paramater within your request, where `#` corresponds to the index of the background you would like to use.
+
+On The Fly Battle Maps provides the following default backgrounds:
+
+1. Grass Texture
+
+_**Example - Default Background**_
+```
+http://otfbm.com/D3-Goblin/A1-Goblin/=1
+```
+
+**Custom Backgrounds**
+Callers can add custom backgrounds to their maps by providing the image's url in the map request.
+
+Maps provided by callers are expected to meet the following requirements:
+
+* Maps are expected to have a grid scale of 40 px
+* Maps are expected to be fitted to the grid size requested in the url. So if a map is 23x12, then the caller is expected to provide a size of 23x12 when making a map request. 
+
+_**Example - Default Background**_
+```
+http://otfbm.com/E7p-Zombie/I3p-Zombie?bg=https://i.imgur.com/k99s0ch.jpg
+```

--- a/board.js
+++ b/board.js
@@ -1,13 +1,12 @@
 import canvas from "canvas";
 const { Image } = canvas;
 
-const gutterWidth = 15.0; /* Width of the gutter surrounding the map */
-
 export default class Board {
   constructor({
     width,
     height,
     gridsize,
+    zoom,
     padding,
     ctx,
     strokeStyle = "#CCCCCC",
@@ -20,6 +19,7 @@ export default class Board {
     this.strokeStyle = strokeStyle;
     this.state = [];
     this.background = null;
+    this.zoom = zoom;
 
     for (let x = 0; x < width; x++) {
       let arr = [];
@@ -34,9 +34,8 @@ export default class Board {
     this.state[x][y] = item;
   }
 
-  addBackground(background, fitImageToGrid) {
+  addBackground(background) {
     this.background = background;
-    this.fitImageToGrid = fitImageToGrid;
   }
 
   get(x, y) {
@@ -77,16 +76,14 @@ export default class Board {
       const img = new Image();
 
       img.onload = () => {
-        if ( this.fitImageToGrid ) {
-          this.ctx.drawImage(img, gutterWidth, gutterWidth, this.width, this.height);
-        }
-        else {
-          /* When we're not scaling an image to the grid, we should still trim it.
-             This lets us maintain the border without stretching terrain textures */
-          this.ctx.drawImage(img, 
-                            0, 0, this.width, this.height, /* Clip image */
-                            gutterWidth, gutterWidth, this.width, this.height); /* Draw Image */
-        }
+
+        /* We don't want to scale images because we're assuming that any 
+           default maps or user-provided maps meet the specifications we 
+           outlined in the README.
+           Instead of scaling, trim provided image to the map */
+        this.ctx.drawImage(img, 
+                          0, 0, this.width, this.height, /* Clip image */
+                          this.padding, this.padding, this.width * this.zoom, this.height * this.zoom); /* Draw Image */
       };
       img.onerror = (err) => {
         throw err;

--- a/board.js
+++ b/board.js
@@ -1,6 +1,8 @@
 import canvas from "canvas";
 const { Image } = canvas;
 
+const gutterWidth = 15.0; /* Width of the gutter surrounding the map */
+
 export default class Board {
   constructor({
     width,
@@ -32,8 +34,9 @@ export default class Board {
     this.state[x][y] = item;
   }
 
-  addBackground(background) {
+  addBackground(background, fitImageToGrid) {
     this.background = background;
+    this.fitImageToGrid = fitImageToGrid;
   }
 
   get(x, y) {
@@ -72,8 +75,18 @@ export default class Board {
 
     if (this.background) {
       const img = new Image();
+
       img.onload = () => {
-        this.ctx.drawImage(img, 0, 0);
+        if ( this.fitImageToGrid ) {
+          this.ctx.drawImage(img, gutterWidth, gutterWidth, this.width, this.height);
+        }
+        else {
+          /* When we're not scaling an image to the grid, we should still trim it.
+             This lets us maintain the border without stretching terrain textures */
+          this.ctx.drawImage(img, 
+                            0, 0, this.width, this.height, /* Clip image */
+                            gutterWidth, gutterWidth, this.width, this.height); /* Draw Image */
+        }
       };
       img.onerror = (err) => {
         throw err;

--- a/draw-canvas.js
+++ b/draw-canvas.js
@@ -15,6 +15,11 @@ export default function main(pathname, backgroundImage) {
   const canv = createCanvas(width + 2 * PADDING, height + 2 * PADDING);
   const ctx = canv.getContext("2d");
 
+  /* When given a caller-provided image, we expect it to be given to 
+     us in a size appropriate to the grid they're creating, so we can
+     safely scale it. */
+  const fitImageToGrid = null != backgroundImage;
+
   const board = new Board({
     ctx,
     width,
@@ -23,7 +28,7 @@ export default function main(pathname, backgroundImage) {
     padding: PADDING,
   });
 
-  board.addBackground(backgroundImage || input.background);
+  board.addBackground(backgroundImage || input.background, fitImageToGrid);
 
   for (const { x, y, item } of input.tokens) {
     board.placeItem(x, y, item);

--- a/draw-canvas.js
+++ b/draw-canvas.js
@@ -14,21 +14,18 @@ export default function main(pathname, backgroundImage) {
   const height = (input.board.height >=52 ? 52 : input.board.height) * gridsize;
   const canv = createCanvas(width + 2 * PADDING, height + 2 * PADDING);
   const ctx = canv.getContext("2d");
-
-  /* When given a caller-provided image, we expect it to be given to 
-     us in a size appropriate to the grid they're creating, so we can
-     safely scale it. */
-  const fitImageToGrid = null != backgroundImage;
+  const zoom = input.zoom;
 
   const board = new Board({
     ctx,
     width,
     height,
     gridsize,
+    zoom,
     padding: PADDING,
   });
 
-  board.addBackground(backgroundImage || input.background, fitImageToGrid);
+  board.addBackground(backgroundImage || input.background);
 
   for (const { x, y, item } of input.tokens) {
     board.placeItem(x, y, item);


### PR DESCRIPTION
Added logic to fit background images within the coordinate gutter.

### Justification
I think leaving the grid size requirements and dimensions up to the caller is fine, but making them account for the size of the gutter imo is pretty inconvenient.

### Test Procedure - Manual
**Default textures**
1. Provide a url with one of the default images (grass) with the default sizing of 10x10
   Ensure that the grass texture is fit within the map borders and the image is not stretched
2. Provide the same url with an extended sizing of 24x24
   Ensure that the grass texture is fit within the map borders and the image is not stretched

**User provided map**
Map for testing: `https://i.imgur.com/k99s0ch.jpg`
1. Provide a url with the above image provided, using the default sizing of 10x10
    Ensure that the image is fit within the coordinate gutter