### PR TITLE
use jpeg to reduce download sizes

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,11 +38,11 @@ export default function createServer() {
     }
 
     const canvas = drawCanvas(request.params["*"], backgroundImage);
-    const data = canvas.toDataURL("image/png", 1);
+    const data = canvas.toDataURL("image/jpeg", { quality: 1 });
     const stripped = data.replace(/^data:image\/\w+;base64,/, "");
     const buff = new Buffer(stripped, "base64");
 
-    reply.type("image/png").send(buff);
+    reply.type("image/jpeg").send(buff);
   });
 
   return server;


### PR DESCRIPTION
This reduces the final file size by a lot. In my test case, it reduced the output from 2.7mb down to ~500kb while still looking pretty good. The jpeg quality has been set to 100%